### PR TITLE
Move duounix_build_pam to main configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ configuration in this role, because those will vary widely by use case.
 | duounix_conf_dir              | /etc/duo                                                      |                                           |
 | duounix_login_config          | `{failmode: secure, pushinfo: yes, autopush: no, prompts: 3}` | any extra config you want for login_duo   |
 | duounix_pam_config            | `{failmode: secure, pushinfo: yes, autopush: no, prompts: 3}` | any extra config you want for pam_duo     |
+| duounix_build_pam             | yes                                                           |                                           |
 
 If building from source, the following variables take effect:
 
@@ -27,4 +28,3 @@ If building from source, the following variables take effect:
 | duounix_path                  | https://dl.duosecurity.com/                                   |                                           |
 | duounix_version               | 1.9.18                                                        |                                           |
 | duounix_prefix_dir            | /usr                                                          |                                           |
-| duounix_build_pam             | yes                                                           |                                           |


### PR DESCRIPTION
Even if Duo isn't built from source, duounix_build_pam still has an
effect - it installs a configuration file.
Because of this, I've moved the setting in to the main configuration
section of the README to show it is independent of being a source
related option.