### PR TITLE
Update repository to include multiarch info and use https

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -8,8 +8,8 @@
   when: ansible_os_family == 'Debian'
 
 - name: Install the repo (Debian-like)
-  apt_repository: >
-    repo='deb http://pkg.duosecurity.com/{{ ansible_distribution }} {{ ansible_distribution_release }} main'
+  apt_repository:
+    repo: 'deb [arch=amd64] https://pkg.duosecurity.com/{{ ansible_distribution }} {{ ansible_distribution_release }} main'
   when: ansible_os_family == 'Debian'
 
 


### PR DESCRIPTION
The current Duo documentation has been updated to make the apt entry
multiarch aware and to use https by default.
https://duo.com/docs/duounix
This commit brings those changes to the role.